### PR TITLE
Pickle cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ be updated by running the following steps:
     npm start
     ```
 
+4. Update `NormalizationData.VERSION`:\
+   This library keeps cache files in `$HOME/.cache/ens_normalize` to speed up loading.
+   To make sure existing users regenerate their cache after a version update,
+   please increment the `NormalizationData.VERSION` constant in [normalization.py](/ens_normalize/normalization.py).
+   The first import of the new version will automatically regenerate the cache.
+
 ### Build and test
 
 Installs dependencies, runs validation tests and builds the wheel.

--- a/ens_normalize/normalization.py
+++ b/ens_normalize/normalization.py
@@ -361,6 +361,9 @@ def group_names_to_ids(groups, whole_map):
 
 
 class NormalizationData:
+    # Increment VERSION when the spec changes
+    # or if the code in this class changes.
+    # It will force the cache to be regenerated.
     VERSION = 1
 
     def __init__(self):


### PR DESCRIPTION
Pickle is stored in `$HOME/.cache/ens_normalize/normalization_data.pkl`.

Load times on Macbook M2:
```python
%timeit load_normalization_data()
# 35.4 ms ± 266 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%time import ens_normalize
# CPU times: user 68.6 ms, sys: 9.27 ms, total: 77.9 ms
# Wall time: 77.1 ms
```

`NormalizationData` class contains a `VERSION` constant that should be incremented with every data update.