### PR TITLE
is_ens_normalizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ ens_normalize('Nick.ETH')
 # note: ens_normalize does not enforce any constraints that might be applied by a particular registrar. For example, the registrar for names that are a subname of '.eth' enforces a 3-character minimum and this constraint is not enforced by ens_normalize.
 ```
 
+Check if a name is *normalizable* (see Glossary):
+
+```python
+from ens_normalize import is_ens_normalizable
+# str -> bool
+is_ens_normalizable('Nick.ETH')
+# True
+```
+
 Inspect issues with disallowed names:
 
 ```python

--- a/ens_normalize/__init__.py
+++ b/ens_normalize/__init__.py
@@ -6,6 +6,7 @@ from .normalization import (
     ens_tokenize,
     ens_normalizations,
     is_ens_normalized,
+    is_ens_normalizable,
     DisallowedSequence,
     DisallowedSequenceType,
     CurableSequence,

--- a/ens_normalize/normalization.py
+++ b/ens_normalize/normalization.py
@@ -1159,3 +1159,11 @@ def is_ens_normalized(name: str) -> bool:
     (i.e. `ens_normalize(name) == name`).
     """
     return ens_process(name, do_normalize=True).normalized == name
+
+
+def is_ens_normalizable(name: str) -> bool:
+    """
+    Checks if the input string is ENS normalizable
+    (i.e. `ens_normalize(name)` will not raise `DisallowedSequence`).
+    """
+    return ens_process(name).error is None

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -9,6 +9,7 @@ from ens_normalize import (
     ens_tokenize,
     ens_normalizations,
     is_ens_normalized,
+    is_ens_normalizable,
     DisallowedSequence,
     DisallowedSequenceType,
     CurableSequence,
@@ -416,3 +417,9 @@ def test_ignorable_name():
     assert e.type == CurableSequenceType.EMPTY_LABEL
     assert e.index == 0
     assert e.sequence == '\ufe0f\ufe0f'
+
+
+def test_is_normalizable():
+    assert is_ens_normalizable('nick.eth')
+    assert not is_ens_normalizable('ni_ck.eth')
+    assert is_ens_normalizable('')


### PR DESCRIPTION
Adds a helper function to check if a name is *normalizable* but not necessarily *normalized*.